### PR TITLE
fix(deps): lock the DA into terraform version 1.10.5

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -2235,7 +2235,8 @@
               "description": "The Secrets Manage Instance ID"
             }
           ],
-          "install_type": "fullstack"
+          "install_type": "fullstack",
+          "terraform_version": "1.10.5"
         },
         {
           "label": "Deploy to Kubernetes",
@@ -4431,7 +4432,8 @@
               "description": "The CI pipeline Id"
             }
           ],
-          "install_type": "fullstack"
+          "install_type": "fullstack",
+          "terraform_version": "1.10.5"
         }
       ]
     }


### PR DESCRIPTION

        This PR ensures that the `ibm_catalog.json` file includes the required `terraform_version` field.

        An upcoming version of **`common-dev-assets`** will introduce an updated `pre-commit` hook that enforces this check. Applying this change now ensures compatibility with the new hook and avoids future commit failures.
        